### PR TITLE
Add documentation for replacing devices while preserving history

### DIFF
--- a/en-eng/Readme.md
+++ b/en-eng/Readme.md
@@ -14,7 +14,7 @@ We are contributing to this project on our spare time. If you do consider that i
 ## IMPORTANT
 
 * We recommend Domoticz 2025.2 or higher (stable8 requires Python 3.11+)
-* The Device Widget Replace function is not supported as Domoticz doesn't notify the plugin of such changes
+* Replacing a device's widget via Domoticz isn't supported (Domoticz doesn't notify the plugin), but you can keep the old device's history with [Replace a Device](HowTo_Replace_Device.md)
 
 ## Introduction
 
@@ -61,6 +61,7 @@ We are contributing to this project on our spare time. If you do consider that i
 * [Build a ZigBee mesh network](HowTo_Build-a-ZigBee-network.md)
 * [Add a new device](HowTo_Pairing-device.md)
 * [Remove a Device](HowTo_Remove-device.md)
+* [Replace a Device while keeping its Domoticz history](HowTo_Replace_Device.md)
 * [Device parameters](HowTo_Device-parameters.md)
 * [Use the plugin tools](HowTo_Using-tools.md)
 * [Group Management](HowTo_Group-management.md)


### PR DESCRIPTION
## Summary
Updated the README to clarify the device widget replacement limitation and added documentation for an alternative approach that preserves device history in Domoticz.

## Key Changes
- Clarified the existing limitation: replacing a device's widget via Domoticz UI is not supported because Domoticz doesn't notify the plugin of such changes
- Added a workaround note directing users to a new guide that explains how to replace a device while keeping its Domoticz history
- Added a new entry in the "How To" documentation index linking to the device replacement guide

## Details
The changes improve user experience by:
1. Making the limitation more explicit and user-friendly
2. Providing a documented solution for users who need to replace devices without losing historical data
3. Maintaining consistency with the project's documentation structure by adding the new guide to the table of contents

https://claude.ai/code/session_01QMpvntx9xDhTre7snpH3od